### PR TITLE
Added support for multiple databases at once

### DIFF
--- a/backend/api/log/controllers/log.js
+++ b/backend/api/log/controllers/log.js
@@ -1,8 +1,17 @@
 'use strict';
 
+const { sanitizeEntity } = require('strapi-utils/lib');
+
 /**
  * Read the documentation (https://strapi.io/documentation/v3.x/concepts/controllers.html#core-controllers)
  * to customize this controller
  */
 
-module.exports = {};
+module.exports = {
+  create: async (ctx) => {
+    const log = await strapi.services['log'].create({
+      ...ctx.request.body
+    });
+    return sanitizeEntity(log, { model: strapi.models.log });
+  }
+};

--- a/backend/api/log/models/log.settings.json
+++ b/backend/api/log/models/log.settings.json
@@ -1,5 +1,6 @@
 {
   "kind": "collectionType",
+  "connection": "logs",
   "collectionName": "logs",
   "info": {
     "name": "log"

--- a/backend/config/database.js
+++ b/backend/config/database.js
@@ -16,5 +16,20 @@ module.exports = ({ env }) => ({
         ssl: env.bool('DATABASE_SSL', false),
       },
     },
+    logs: {
+      connector: 'mongoose',
+      settings: {
+        host: env('DATABASE_HOST', '127.0.0.1'),
+        srv: env.bool('DATABASE_SRV', false),
+        port: env.int('DATABASE_PORT', 27017),
+        database: env('DATABASE_NAME', 'logs'),
+        username: env('DATABASE_USERNAME', ''),
+        password: env('DATABASE_PASSWORD', ''),
+      },
+      options: {
+        authenticationDatabase: env('AUTHENTICATION_DATABASE', null),
+        ssl: env.bool('DATABASE_SSL', false),
+      },
+    },
   },
 });


### PR DESCRIPTION
Logs will be added into another database `logs`.
There is some issue with adding data from `strapi-admin-panel`. Data is getting added but throwing error because of `created_by` and `updated_by`. None the less works fine as adding data to logs is not getting added from admin panel anyways.